### PR TITLE
4 Added Dockerfile and automate build and release to docker hub

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -1,0 +1,25 @@
+name: Automate build and release to docker hub
+on:
+  pull_request:
+    branches: [ "master" ]
+    types:
+     - closed
+
+jobs:
+  build:
+    # Build only merged PRs
+    if: (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        run: |
+          docker buildx rm
+          docker buildx create --use --name webhook-sentry-builder
+          docker buildx build --push --platform linux/amd64,linux/arm64 -t ${{ secrets.DOCKERHUB_REPO }}:latest --file Dockerfile .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.16-alpine
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY . ./
+
+RUN go build -o /webhook-sentry
+EXPOSE 9090
+CMD /webhook-sentry
+


### PR DESCRIPTION
This PR adds docker support, and builds and releases the image to docker hub.
The build and release action is triggered when a PR is merged into master.

We need your help to set up the following github secrets in order to work, before this is merged:

`DOCKERHUB_TOKEN`
`DOCKERHUB_USERNAME`
`DOCKERHUB_REPO`

